### PR TITLE
avcodec/jpeg2000dec: fix cdef remapping out-of-bounds write (CVE-2025-9951)

### DIFF
--- a/libavcodec/jpeg2000dec.c
+++ b/libavcodec/jpeg2000dec.c
@@ -271,6 +271,25 @@ static int get_siz(Jpeg2000DecoderContext *s)
         return AVERROR_INVALIDDATA;
     }
 
+    for (i = 0; i < s->ncomponents; i++) {
+        if (s->cdef[i] < 0) {
+            for (i = 0; i < s->ncomponents; i++) {
+                s->cdef[i] = i + 1;
+            }
+            if ((s->ncomponents & 1) == 0)
+                s->cdef[s->ncomponents-1] = 0;
+        }
+    }
+    // after here we no longer have to consider negative cdef
+
+    int cdef_used = 0;
+    for (i = 0; i < s->ncomponents; i++)
+        cdef_used |= 1<<s->cdef[i];
+
+    // Check that the channels we have are what we expect for the number of components
+    if (cdef_used != ((int[]){0,2,3,14,15})[s->ncomponents])
+        return AVERROR_INVALIDDATA;
+
     for (i = 0; i < s->ncomponents; i++) { // Ssiz_i XRsiz_i, YRsiz_i
         uint8_t x    = bytestream2_get_byteu(&s->g);
         s->cbps[i]   = (x & 0x7f) + 1;
@@ -283,7 +302,9 @@ static int get_siz(Jpeg2000DecoderContext *s)
             av_log(s->avctx, AV_LOG_ERROR, "Invalid sample separation %d/%d\n", s->cdx[i], s->cdy[i]);
             return AVERROR_INVALIDDATA;
         }
-        log2_chroma_wh |= s->cdy[i] >> 1 << i * 4 | s->cdx[i] >> 1 << i * 4 + 2;
+        int i_remapped = s->cdef[i] ? s->cdef[i]-1 : (s->ncomponents-1);
+
+        log2_chroma_wh |= s->cdy[i] >> 1 << i_remapped * 4 | s->cdx[i] >> 1 << i_remapped * 4 + 2;
     }
 
     s->numXtiles = ff_jpeg2000_ceildiv(s->width  - s->tile_offset_x, s->tile_width);
@@ -2852,17 +2873,6 @@ static int jpeg2000_decode_frame(AVCodecContext *avctx, AVFrame *picture,
 
     if (ret = jpeg2000_read_bitstream_packets(s))
         goto end;
-
-    for (int x = 0; x < s->ncomponents; x++) {
-        if (s->cdef[x] < 0) {
-            for (x = 0; x < s->ncomponents; x++) {
-                s->cdef[x] = x + 1;
-            }
-            if ((s->ncomponents & 1) == 0)
-                s->cdef[s->ncomponents-1] = 0;
-            break;
-        }
-    }
 
     avctx->execute2(avctx, jpeg2000_decode_tile, picture, NULL, s->numXtiles * s->numYtiles);
 


### PR DESCRIPTION
Fixes #123 (CVE-2025-9951).

The JPEG2000 decoder on the current 7.1.1 base has a heap buffer overflow in `write_frame_8`: a crafted `cdef` box can remap a component onto an arbitrary plane, and `WRITE_FRAME` uses that index without bounds-checking, writing a larger plane's data past a smaller plane's buffer.

This backports the upstream fix:
- `104d6846c1be` avcodec/jpeg2000dec: move cdef default check into get_siz()
- `01a292c7e365` avcodec/jpeg2000dec: implement cdef remapping during pixel format matching

`get_siz()` now finalizes `cdef` early and rejects channel/component combinations that don't match, and the chroma-shift computation uses the remapped index.

Verified with AddressSanitizer on this 7.1.1 build:
- before: `heap-buffer-overflow WRITE ... write_frame_8 libavcodec/jpeg2000dec.c` on the PoC from #123
- after: the PoC is rejected as invalid data (no overflow), and valid JPEG2000 input still decodes normally
